### PR TITLE
Add parameter parser and letter switcher functionality

### DIFF
--- a/manipulator.js
+++ b/manipulator.js
@@ -1,0 +1,24 @@
+"use strict";
+
+function switchLetters(text, params, callback) {
+    var manipulated = text;
+
+    if( (params['s'] && params['r']) && 
+        (params['s'].length === params['r'].length)
+    ) {
+        
+        var searchLetters = params['s'],
+            replaceLetters = params['r'];
+
+        for( var i=0; i < searchLetters.length; i++ ) {
+            var re = RegExp(searchLetters[i],"g");
+            manipulated = manipulated.replace(re, replaceLetters[i]);
+        }
+    }
+
+    callback(manipulated);
+}
+
+module.exports = {
+    switchLetters: switchLetters
+};

--- a/slash_bot.js
+++ b/slash_bot.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var translator = require('./translator'),
+    manipulator = require('./manipulator'),
     rp = require('request-promise');
 
 function processRequest(request, response, slashToken) {
@@ -8,25 +9,52 @@ function processRequest(request, response, slashToken) {
         response.end("Thank you very much for your request.\nThe translation will be posted shortly");
         var text = request.body.text;
         var responseUrl = request.body.response_url;
-
-        translator.translate(text, function (translated) {
-            var responseBody = {
-                response_type: 'in_channel',
-                text: translated
-            };
-            rp({
-                method: 'POST',
-                uri: responseUrl,
-                body: responseBody,
-                json: true,
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            });
+                
+        extractParameters(text, function( text, params ) {
+            if (params) {
+                manipulator.switchLetters(text, params, sendResult);
+            } else {
+                translator.translate(text, sendResult);
+            }
         });
+
     } else {
         response.end();
     }
+}
+
+function sendResult( text ) {
+    var responseBody = {
+        response_type: 'in_channel',
+        text: translated
+    };
+    rp({
+        method: 'POST',
+        uri: responseUrl,
+        body: responseBody,
+        json: true,
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+}
+
+function extractParameters(text, callback) {
+    var findRegex = /%\S+/g,
+        replRegex = /%\S+\s?/g,
+        rawParams = text.match(regexp);
+    
+    if (rawParams.length > 0) {
+        var params = {}
+        for (var i = 0; i < rawParams; i++) {
+            var rawParam = rawParams[i].split('=');
+            params[rawParam[0]] = rawParam[1].split(',').filter(Boolean);
+        } 
+        
+        callback( text.replace(replRegex, ''), params );
+    }
+
+    return callback( text, null );
 }
 
 module.exports = {


### PR DESCRIPTION
So Junge! Parameter können jetzt alla `%key=value` oder `%key=value1,value2,...` mit `/cipher` verwendet werden. Und wenn man `was auch immer für nen text %s=n,m %r=k,l` würde das Ergebnis ungefähr so aussehen: `was auch iller für kek text` 
